### PR TITLE
git ignore .bundle and vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ nbproject
 pkg
 *.swp
 spec/dummy
+.bundle
+vendor


### PR DESCRIPTION
These folders get generated if you have your bundle config setup to
install your gems in a per-project vendor directory. No need to include
these in the repo.