### PR TITLE
Do not attempt to serialize columns that dont exist.

### DIFF
--- a/app/services/versions_adapter.rb
+++ b/app/services/versions_adapter.rb
@@ -6,7 +6,9 @@ class VersionsAdapter
       if element.respond_to?(:versions)
         versions = element.versions.order(:object, created_at: :asc)
         versions.each do |version|
-          prototype = version.object.nil? ? element.class.new : YamlAdapter.create(version.object, element.class)
+          prototype = version.object.nil? ?
+            element.class.new :
+            YamlAdapter.new(version.object, element.class).deserialize
           prototype.who = version.whodunnit
           prototype.version_id = version.id
           prototype.version_event = version.event

--- a/app/services/yaml_adapter.rb
+++ b/app/services/yaml_adapter.rb
@@ -1,6 +1,27 @@
 class YamlAdapter
-  def self.create text, klass
-    data = YAML.load(text)
-    klass.new(data)
+  attr_reader :payload, :klass
+
+  def initialize text, klass
+    @data = YAML.load(text)
+    @klass = klass
+  end
+
+  def deserialize
+    @klass.new(permitted_data)
+  end
+
+  private
+
+  # The below two methods prevent papertrail from
+  # attempting to instantiate models with attributes
+  # they do not have definitions for or do not have
+  # the corresponding columns in the database.
+  #
+  # Both cases are exceptional, so we filter this here.
+  def permitted_data
+    keys = @klass.column_names.to_set
+    @data.keep_if do |key, _|
+      keys.include?(key)
+    end
   end
 end


### PR DESCRIPTION
You cannot serialize attributes that dont exist on a model.

E.g. `Spree::Order.new(foo: :bar)` is exceptional, because foo is not
defined as an attr_writer, or as an attribute on the database table.

Due to upgrading, and changing data models, it's difficult to properly
represent these changes. Instead we should not be serializing objects at
all, but I believe it is done how it is currently for ease of use and
display purposes.