### PR TITLE
Lock SQLite3 to version 1.3

### DIFF
--- a/solidus_papertrail.gemspec
+++ b/solidus_papertrail.gemspec
@@ -32,5 +32,5 @@ require 'solidus_papertrail/version'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'rspec-rails',  '~> 3'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end


### PR DESCRIPTION
SQLite3 v1.4 was released on February 4th, which breaks compatibility with ActiveRecord's adapter for said DB engine.