### PR TITLE
Use SolidusSupport::EngineExtensions

### DIFF
--- a/lib/solidus_papertrail/engine.rb
+++ b/lib/solidus_papertrail/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusPapertrail
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace ::Spree
 


### PR DESCRIPTION
This PR prepares this extension for Solidus 3.0. Tests pass for v2.9, v2.10, v2.11, and `master`.

The only change required was: the Decorators sub-module was deprecated. The warning told us to update and include the parent EngineExtensions module instead.

Closes #46.